### PR TITLE
uses shift slli instead of mul in gpio_init

### DIFF
--- a/examples/longan_nano_led.asm
+++ b/examples/longan_nano_led.asm
@@ -38,7 +38,7 @@ gpio_init:
 
 gpio_init_config:
     # multiply pin number by 4 to get shift amount
-    slli a1,a1,2
+    slli a1, a1, 2
 
     # load current config
     lw t1, 0(t0)

--- a/examples/longan_nano_led.asm
+++ b/examples/longan_nano_led.asm
@@ -38,8 +38,7 @@ gpio_init:
 
 gpio_init_config:
     # multiply pin number by 4 to get shift amount
-    addi t1, zero, 4
-    mul a1, a1, t1
+    slli a1,a1,2
 
     # load current config
     lw t1, 0(t0)

--- a/examples/longan_nano_sdcard.asm
+++ b/examples/longan_nano_sdcard.asm
@@ -125,8 +125,7 @@ gpio_init:
     addi a1, a1, -8
 gpio_init_config:
     # multiply pin number by 4 to get shift amount
-    addi t1, zero, 4
-    mul a1, a1, t1
+    slli a1, a1, 2
 
     # load current config
     lw t1, t0, 0

--- a/examples/longan_nano_usart_echo.asm
+++ b/examples/longan_nano_usart_echo.asm
@@ -41,8 +41,7 @@ gpio_init:
 
 gpio_init_config:
     # multiply pin number by 4 to get shift amount
-    addi t1, zero, 4
-    mul a1, a1, t1
+    slli a1, a1, 2
 
     # load current config
     lw t1, 0(t0)


### PR DESCRIPTION
before:
```
addi t1, zero, 4
mul a1, a1, t1
```
then:
`slli a1, a1, 2`