### PR TITLE
support trailing comments on 'include' lines

### DIFF
--- a/bronzebeard/asm.py
+++ b/bronzebeard/asm.py
@@ -2093,9 +2093,12 @@ def read_lines(path_or_source, *, include=False, include_dirs=None):
         line = Line(path, i, raw_line)
 
         # handle include in the reader
+        # Note that includes are processed before comment stripping, so any trailing
+        # comments on the include line need special processing
         if raw_line.lower().startswith('include '):
             try:
-                _, rel_path = raw_line.split()
+                rel_path, _ = raw_line[8:].split('#')
+                rel_path = rel_path.strip()
             except ValueError:
                 raise AssemblerError('include must specify a file', line)
 


### PR DESCRIPTION
I discovered, after much head scratching and playing with paths and filenames, that in Bronzebeard the **include** directive is processed before lexical analysis and thus before comment stripping. If you accidentally add an in-line comment to the include, you get the confusing error message 'include must specify a file', even if the file exists. None of the code examples have this situation, which is probably why it was never spotted.

This PR addresses the problem by removing any characters after '#', and any remaining whitespace, from the include line before trying to load the file. Manually tested with and without comments.

See issue #25 